### PR TITLE
No setup-java

### DIFF
--- a/.github/workflows/use_pubsub_emulator.yml
+++ b/.github/workflows/use_pubsub_emulator.yml
@@ -9,10 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
       - name: 'Install Cloud SDK'
         uses: google-github-actions/setup-gcloud@v0
         with:


### PR DESCRIPTION
Removing setup-java from GHA workflow to see if the Pub/Sub emulator can still be used.